### PR TITLE
文章の折り返しCSSの追加

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,7 @@ html {
 
   color: #333333;
   background-color: #fafafa;
+  overflow-wrap: anywhere;
 }
 
 *, *::before, *::after {


### PR DESCRIPTION
スマホで見るとはみ出している箇所があったので、折り返しのCSSを追加すると良いかもです。

<img width="790" height="760" alt="image" src="https://github.com/user-attachments/assets/f28999d3-ac6e-4459-bf1e-aa7f942321bf" />
